### PR TITLE
[lua] Fix loading of dynamic libraries. JB#55272

### DIFF
--- a/lua-5.3.0-autotoolize.patch
+++ b/lua-5.3.0-autotoolize.patch
@@ -55,7 +55,7 @@ diff -up lua-5.3.0/configure.ac.autoxxx lua-5.3.0/configure.ac
 +  LUA_DL_DEFS="#define LUA_DL_DYLD"
 +elif test "x$use_os" == "xposix"; then
 +  POSIX_DEFS="#define LUA_USE_POSIX"
-+  LUA_DL_DEFS="#define LUA_DL_DLOPEN"
++  LUA_DL_DEFS="#define LUA_USE_DLOPEN"
 +  LUA_LIBS="$LUA_LIBS -ldl"
 +fi
 +AC_SUBST(POSIX_DEFS)

--- a/lua.changes
+++ b/lua.changes
@@ -1,3 +1,6 @@
+* Tue Sep 21 2021 Björn Bidar <bjorn.bidar@jolla.com> - 5.3.5-4
+- [lua] Fix loading of dynamic libraries. JB#55272
+
 * Thu Feb 13 2020 Marko Saukko <marko.saukko@jolla.com> - 5.3.5-3
 - Drop ncurses build dep. Fixes JB#48953
 


### PR DESCRIPTION
loader.c uses `LUA_USE_DLOPEN` instead of `LUA_DL_DLOPEN` since
https://github.com/lua/lua/commit/8cd395564c9b547e2ded1d4eb67654effcb86494 (>=5.2.0)